### PR TITLE
[service-template] Implement Stripe webhook handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,15 @@ Repositories can operate against Prisma or Supabase. By default the application 
 
 Environment variables are centralised in `src/config/config.ts` with Joi validation. Update that file if you introduce new configuration keys so they are typed and validated automatically.
 
+### Stripe configuration
+
+Provide the following environment variables to enable Stripe integrations:
+
+| Variable                 | Description                                  |
+| ------------------------ | -------------------------------------------- |
+| `STRIPE_API_KEY`         | Secret key used for outbound Stripe requests |
+| `STRIPE_WEBHOOK_SECRET`  | Signing secret for validating webhook calls  |
+
 ### Redis configuration
 
 Pub/sub and GraphQL caching rely on Redis. Configure the connection with the following environment variables (defaults are shown):

--- a/src/billing/application/use-cases/handle-customer-subscription-updated.use-case.ts
+++ b/src/billing/application/use-cases/handle-customer-subscription-updated.use-case.ts
@@ -1,0 +1,16 @@
+import { Injectable, Logger } from '@nestjs/common';
+import Stripe from 'stripe';
+
+@Injectable()
+export class HandleCustomerSubscriptionUpdatedUseCase {
+  private readonly logger = new Logger(
+    HandleCustomerSubscriptionUpdatedUseCase.name,
+  );
+
+  execute(event: Stripe.CustomerSubscriptionUpdatedEvent): void {
+    const subscription = event.data.object;
+    this.logger.debug(
+      `Subscription ${subscription.id} updated with status ${subscription.status}`,
+    );
+  }
+}

--- a/src/billing/application/use-cases/handle-invoice-payment-succeeded.use-case.ts
+++ b/src/billing/application/use-cases/handle-invoice-payment-succeeded.use-case.ts
@@ -1,0 +1,20 @@
+import { Injectable, Logger } from '@nestjs/common';
+import Stripe from 'stripe';
+
+@Injectable()
+export class HandleInvoicePaymentSucceededUseCase {
+  private readonly logger = new Logger(
+    HandleInvoicePaymentSucceededUseCase.name,
+  );
+
+  execute(event: Stripe.InvoicePaymentSucceededEvent): void {
+    const invoice = event.data.object;
+    const customerId =
+      typeof invoice.customer === 'string'
+        ? invoice.customer
+        : (invoice.customer?.id ?? 'unknown');
+    this.logger.debug(
+      `Invoice ${invoice.id} payment succeeded for customer ${customerId}`,
+    );
+  }
+}

--- a/src/billing/billing.module.ts
+++ b/src/billing/billing.module.ts
@@ -1,10 +1,13 @@
 import { Module } from '@nestjs/common';
 import { BillingController } from './presentation/billing/billing.controller';
 import { StripeAdapter } from './infrastructure/payment/stripe.adapter';
+import { StripeWebhookService } from './infrastructure/payment/stripe-webhook.service';
 import { PAYMENT_GATEWAY_TOKEN } from './infrastructure/payment/payment-gateway.interface';
 import { UserCreatedListener } from './application/listeners/user-created.listener';
 import { CreateSubscriptionUseCase } from './application/use-cases/create-subscription.use-case';
 import { CancelSubscriptionUseCase } from './application/use-cases/cancel-subscription.use-case';
+import { HandleInvoicePaymentSucceededUseCase } from './application/use-cases/handle-invoice-payment-succeeded.use-case';
+import { HandleCustomerSubscriptionUpdatedUseCase } from './application/use-cases/handle-customer-subscription-updated.use-case';
 import { TransactionsModule } from '../transactions/transactions.module';
 import { CUSTOMER_REPOSITORY } from './domain/repositories/customer.repository';
 import { PLAN_REPOSITORY } from './domain/repositories/plan.repository';
@@ -31,13 +34,17 @@ import { AppConfig } from '../config/config';
   imports: [TransactionsModule],
   controllers: [BillingController],
   providers: [
+    StripeAdapter,
     {
       provide: PAYMENT_GATEWAY_TOKEN,
-      useClass: StripeAdapter,
+      useExisting: StripeAdapter,
     },
+    StripeWebhookService,
     UserCreatedListener,
     CreateSubscriptionUseCase,
     CancelSubscriptionUseCase,
+    HandleInvoicePaymentSucceededUseCase,
+    HandleCustomerSubscriptionUpdatedUseCase,
     PrismaCustomerRepository,
     SupabaseCustomerRepository,
     PrismaPlanRepository,

--- a/src/billing/infrastructure/payment/stripe-webhook.service.ts
+++ b/src/billing/infrastructure/payment/stripe-webhook.service.ts
@@ -1,0 +1,18 @@
+import { BadRequestException, Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import Stripe from 'stripe';
+import { AppConfig } from '../../../config/config';
+
+@Injectable()
+export class StripeWebhookService {
+  constructor(private readonly configService: ConfigService<AppConfig>) {}
+
+  constructEvent(payload: Buffer | string, signature: string): Stripe.Event {
+    const secret = this.configService.get<string>('stripeWebhookSecret');
+    if (!secret) {
+      throw new BadRequestException('Stripe webhook secret is not configured');
+    }
+
+    return Stripe.webhooks.constructEvent(payload, signature, secret);
+  }
+}

--- a/src/billing/presentation/billing/billing.controller.spec.ts
+++ b/src/billing/presentation/billing/billing.controller.spec.ts
@@ -1,0 +1,166 @@
+import { BadRequestException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Test, TestingModule } from '@nestjs/testing';
+import Stripe from 'stripe';
+import type { Request } from 'express';
+import { BillingController } from './billing.controller';
+import { CreateSubscriptionUseCase } from '../../application/use-cases/create-subscription.use-case';
+import { CancelSubscriptionUseCase } from '../../application/use-cases/cancel-subscription.use-case';
+import { StripeWebhookService } from '../../infrastructure/payment/stripe-webhook.service';
+import { HandleInvoicePaymentSucceededUseCase } from '../../application/use-cases/handle-invoice-payment-succeeded.use-case';
+import { HandleCustomerSubscriptionUpdatedUseCase } from '../../application/use-cases/handle-customer-subscription-updated.use-case';
+
+describe('BillingController - Stripe webhooks', () => {
+  let controller: BillingController;
+  const webhookSecret = 'whsec_test_secret';
+
+  const createSubscriptionUseCase = {
+    execute: jest.fn(),
+  };
+  const cancelSubscriptionUseCase = {
+    execute: jest.fn(),
+  };
+  const handleInvoicePaymentSucceededUseCase = {
+    execute: jest.fn(),
+  };
+  const handleCustomerSubscriptionUpdatedUseCase = {
+    execute: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [BillingController],
+      providers: [
+        {
+          provide: CreateSubscriptionUseCase,
+          useValue: createSubscriptionUseCase,
+        },
+        {
+          provide: CancelSubscriptionUseCase,
+          useValue: cancelSubscriptionUseCase,
+        },
+        {
+          provide: HandleInvoicePaymentSucceededUseCase,
+          useValue: handleInvoicePaymentSucceededUseCase,
+        },
+        {
+          provide: HandleCustomerSubscriptionUpdatedUseCase,
+          useValue: handleCustomerSubscriptionUpdatedUseCase,
+        },
+        StripeWebhookService,
+        {
+          provide: ConfigService,
+          useValue: {
+            get: (key: string) => {
+              if (key === 'stripeWebhookSecret') {
+                return webhookSecret;
+              }
+              return undefined;
+            },
+          },
+        },
+      ],
+    }).compile();
+
+    controller = module.get<BillingController>(BillingController);
+    jest.clearAllMocks();
+  });
+
+  const buildRequest = (
+    payload: Record<string, unknown>,
+    signature: string,
+  ): Request => {
+    return {
+      headers: {
+        'stripe-signature': signature,
+      },
+      rawBody: Buffer.from(JSON.stringify(payload)),
+      body: payload,
+    } as unknown as Request;
+  };
+
+  it('acknowledges invoice payment succeeded events', async () => {
+    const eventPayload = {
+      id: 'evt_1',
+      object: 'event',
+      type: 'invoice.payment_succeeded',
+      data: {
+        object: {
+          id: 'in_1',
+          object: 'invoice',
+          customer: 'cus_123',
+        },
+      },
+    };
+    const signature = Stripe.webhooks.generateTestHeaderString({
+      payload: JSON.stringify(eventPayload),
+      secret: webhookSecret,
+    });
+
+    const response = await controller.handleStripeWebhook(
+      buildRequest(eventPayload, signature),
+    );
+
+    expect(response).toEqual({ received: true });
+    expect(handleInvoicePaymentSucceededUseCase.execute).toHaveBeenCalledTimes(
+      1,
+    );
+    expect(
+      handleCustomerSubscriptionUpdatedUseCase.execute,
+    ).not.toHaveBeenCalled();
+  });
+
+  it('acknowledges customer subscription updated events', async () => {
+    const eventPayload = {
+      id: 'evt_2',
+      object: 'event',
+      type: 'customer.subscription.updated',
+      data: {
+        object: {
+          id: 'sub_123',
+          object: 'subscription',
+          status: 'active',
+        },
+      },
+    };
+    const signature = Stripe.webhooks.generateTestHeaderString({
+      payload: JSON.stringify(eventPayload),
+      secret: webhookSecret,
+    });
+
+    const response = await controller.handleStripeWebhook(
+      buildRequest(eventPayload, signature),
+    );
+
+    expect(response).toEqual({ received: true });
+    expect(
+      handleCustomerSubscriptionUpdatedUseCase.execute,
+    ).toHaveBeenCalledTimes(1);
+    expect(handleInvoicePaymentSucceededUseCase.execute).not.toHaveBeenCalled();
+  });
+
+  it('rejects requests without signature header', async () => {
+    await expect(
+      controller.handleStripeWebhook({ headers: {} } as unknown as Request),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('rejects requests with invalid signature', async () => {
+    const eventPayload = {
+      id: 'evt_3',
+      object: 'event',
+      type: 'invoice.payment_succeeded',
+      data: {
+        object: {
+          id: 'in_2',
+          object: 'invoice',
+          customer: 'cus_321',
+        },
+      },
+    };
+
+    await expect(
+      controller.handleStripeWebhook(buildRequest(eventPayload, 'invalid')),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+});

--- a/src/billing/presentation/billing/billing.controller.ts
+++ b/src/billing/presentation/billing/billing.controller.ts
@@ -1,14 +1,32 @@
-import { Controller, Post, Delete, Body, Param, Req } from '@nestjs/common';
+import {
+  Controller,
+  Post,
+  Delete,
+  Body,
+  Param,
+  Req,
+  BadRequestException,
+  Logger,
+} from '@nestjs/common';
 import { CreateSubscriptionUseCase } from '../../application/use-cases/create-subscription.use-case';
 import { CancelSubscriptionUseCase } from '../../application/use-cases/cancel-subscription.use-case';
 import { Request } from 'express';
 import { CreateSubscriptionDto } from './dto/create-subscription.dto';
+import Stripe from 'stripe';
+import { StripeWebhookService } from '../../infrastructure/payment/stripe-webhook.service';
+import { HandleInvoicePaymentSucceededUseCase } from '../../application/use-cases/handle-invoice-payment-succeeded.use-case';
+import { HandleCustomerSubscriptionUpdatedUseCase } from '../../application/use-cases/handle-customer-subscription-updated.use-case';
 
 @Controller('billing')
 export class BillingController {
+  private readonly logger = new Logger(BillingController.name);
+
   constructor(
     private readonly createSubscriptionUseCase: CreateSubscriptionUseCase,
     private readonly cancelSubscriptionUseCase: CancelSubscriptionUseCase,
+    private readonly stripeWebhookService: StripeWebhookService,
+    private readonly handleInvoicePaymentSucceededUseCase: HandleInvoicePaymentSucceededUseCase,
+    private readonly handleCustomerSubscriptionUpdatedUseCase: HandleCustomerSubscriptionUpdatedUseCase,
   ) {}
 
   /**
@@ -41,8 +59,66 @@ export class BillingController {
    * @returns An object indicating that the webhook was received.
    */
   @Post('webhooks/stripe')
-  handleStripeWebhook(@Req() req: Request) {
-    console.log('Stripe webhook received:', req.body);
+  async handleStripeWebhook(@Req() req: Request) {
+    const signature = req.headers['stripe-signature'];
+    if (!signature) {
+      throw new BadRequestException('Stripe signature header is missing');
+    }
+
+    const payload =
+      (req as Request & { rawBody?: Buffer | string }).rawBody ??
+      (Buffer.isBuffer(req.body)
+        ? req.body
+        : typeof req.body === 'string'
+          ? req.body
+          : JSON.stringify(req.body ?? {}));
+
+    let event: Stripe.Event;
+    try {
+      event = this.stripeWebhookService.constructEvent(
+        payload,
+        Array.isArray(signature) ? signature[0] : signature,
+      );
+    } catch (error) {
+      this.logger.error('Failed to validate Stripe webhook signature', error);
+      throw new BadRequestException('Invalid Stripe signature');
+    }
+
+    await this.dispatchStripeEvent(event);
+
     return { received: true };
+  }
+
+  private async dispatchStripeEvent(event: Stripe.Event) {
+    switch (event.type) {
+      case 'invoice.payment_succeeded':
+        if (this.isInvoicePaymentSucceededEvent(event)) {
+          await Promise.resolve(
+            this.handleInvoicePaymentSucceededUseCase.execute(event),
+          );
+        }
+        break;
+      case 'customer.subscription.updated':
+        if (this.isCustomerSubscriptionUpdatedEvent(event)) {
+          await Promise.resolve(
+            this.handleCustomerSubscriptionUpdatedUseCase.execute(event),
+          );
+        }
+        break;
+      default:
+        this.logger.warn(`Unhandled Stripe event type: ${event.type}`);
+    }
+  }
+
+  private isInvoicePaymentSucceededEvent(
+    event: Stripe.Event,
+  ): event is Stripe.InvoicePaymentSucceededEvent {
+    return event.type === 'invoice.payment_succeeded';
+  }
+
+  private isCustomerSubscriptionUpdatedEvent(
+    event: Stripe.Event,
+  ): event is Stripe.CustomerSubscriptionUpdatedEvent {
+    return event.type === 'customer.subscription.updated';
   }
 }

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -10,6 +10,7 @@ export const configValidationSchema = Joi.object({
   SUPABASE_SERVICE_ROLE_KEY: Joi.string().optional(),
   DATA_PROVIDER: Joi.string().valid('supabase', 'prisma').default('supabase'),
   STRIPE_API_KEY: Joi.string().optional(),
+  STRIPE_WEBHOOK_SECRET: Joi.string().optional(),
   REDIS_HOST: Joi.string().hostname().default('localhost'),
   REDIS_PORT: Joi.number().port().default(6379),
   RABBITMQ_DSN: Joi.string().uri().optional(),
@@ -32,6 +33,7 @@ export interface AppConfig {
   supabaseServiceRoleKey?: string;
   dataProvider: DataProvider;
   stripeApiKey?: string;
+  stripeWebhookSecret?: string;
   gql: GQLConfig;
   redis: RedisConfig;
   rabbit: RabbitMQConfig;
@@ -45,6 +47,7 @@ export const appConfig = (): AppConfig => ({
     process.env.DATA_PROVIDER ?? 'supabase'
   ).toLowerCase() as DataProvider,
   stripeApiKey: process.env.STRIPE_API_KEY,
+  stripeWebhookSecret: process.env.STRIPE_WEBHOOK_SECRET,
   gql: {
     persistedQueriesTTL: +(process.env.PERSISTED_QUERIES_TTL ?? '86400'),
   },


### PR DESCRIPTION
## Summary
- verify Stripe webhook signatures via a dedicated StripeWebhookService and configuration support
- route invoice/payment and subscription update events through new use cases in BillingController
- add controller unit tests for valid and invalid signatures and document required Stripe environment variables

## Testing
- `npm run lint` *(fails: existing lint violations in unrelated modules)*
- `npm run test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68e2bc3e4f608328ae0628144d9512fb