### PR TITLE
[service-template] Add billing service account configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,10 @@ Repositories can operate against Prisma or Supabase. By default the application 
 
 Environment variables are centralised in `src/config/config.ts` with Joi validation. Update that file if you introduce new configuration keys so they are typed and validated automatically.
 
+### Billing configuration
+
+Billing transactions require a service account identifier that is propagated to the transactions service. Configure it through the `BILLING_SERVICE_ACCOUNT_ID` environment variable (defaults to `service_account_123`).
+
 ### Redis configuration
 
 Pub/sub and GraphQL caching rely on Redis. Configure the connection with the following environment variables (defaults are shown):

--- a/src/billing/application/use-cases/create-subscription.use-case.ts
+++ b/src/billing/application/use-cases/create-subscription.use-case.ts
@@ -23,6 +23,10 @@ import {
 } from '../../domain/repositories/subscription.repository';
 import { SubscriptionStatusChangedEvent } from '../../domain/events/subscription-status-changed.event';
 
+export const BILLING_SERVICE_ACCOUNT_ID_TOKEN = Symbol(
+  'BILLING_SERVICE_ACCOUNT_ID_TOKEN',
+);
+
 @Injectable()
 export class CreateSubscriptionUseCase {
   constructor(
@@ -36,6 +40,8 @@ export class CreateSubscriptionUseCase {
     private readonly subscriptionRepository: SubscriptionRepository,
     private readonly transactionsService: TransactionsService,
     private readonly eventEmitter: EventEmitter2,
+    @Inject(BILLING_SERVICE_ACCOUNT_ID_TOKEN)
+    private readonly serviceAccountId: string,
   ) {}
 
   /**
@@ -76,7 +82,7 @@ export class CreateSubscriptionUseCase {
 
     const transaction = await this.transactionsService.createTransaction({
       userId,
-      serviceAccountId: 'service_account_123',
+      serviceAccountId: this.serviceAccountId,
       amountOut: plan.price,
       currency: plan.currency,
       status: TransactionStatus.COMPLETED,

--- a/src/billing/billing.module.ts
+++ b/src/billing/billing.module.ts
@@ -3,7 +3,10 @@ import { BillingController } from './presentation/billing/billing.controller';
 import { StripeAdapter } from './infrastructure/payment/stripe.adapter';
 import { PAYMENT_GATEWAY_TOKEN } from './infrastructure/payment/payment-gateway.interface';
 import { UserCreatedListener } from './application/listeners/user-created.listener';
-import { CreateSubscriptionUseCase } from './application/use-cases/create-subscription.use-case';
+import {
+  BILLING_SERVICE_ACCOUNT_ID_TOKEN,
+  CreateSubscriptionUseCase,
+} from './application/use-cases/create-subscription.use-case';
 import { CancelSubscriptionUseCase } from './application/use-cases/cancel-subscription.use-case';
 import { TransactionsModule } from '../transactions/transactions.module';
 import { CUSTOMER_REPOSITORY } from './domain/repositories/customer.repository';
@@ -36,6 +39,12 @@ import { AppConfig } from '../config/config';
       useClass: StripeAdapter,
     },
     UserCreatedListener,
+    {
+      provide: BILLING_SERVICE_ACCOUNT_ID_TOKEN,
+      useFactory: (config: ConfigService<AppConfig>) =>
+        config.get<string>('billingServiceAccountId') ?? 'service_account_123',
+      inject: [ConfigService],
+    },
     CreateSubscriptionUseCase,
     CancelSubscriptionUseCase,
     PrismaCustomerRepository,

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -10,6 +10,7 @@ export const configValidationSchema = Joi.object({
   SUPABASE_SERVICE_ROLE_KEY: Joi.string().optional(),
   DATA_PROVIDER: Joi.string().valid('supabase', 'prisma').default('supabase'),
   STRIPE_API_KEY: Joi.string().optional(),
+  BILLING_SERVICE_ACCOUNT_ID: Joi.string().optional(),
   REDIS_HOST: Joi.string().hostname().default('localhost'),
   REDIS_PORT: Joi.number().port().default(6379),
   RABBITMQ_DSN: Joi.string().uri().optional(),
@@ -32,6 +33,7 @@ export interface AppConfig {
   supabaseServiceRoleKey?: string;
   dataProvider: DataProvider;
   stripeApiKey?: string;
+  billingServiceAccountId?: string;
   gql: GQLConfig;
   redis: RedisConfig;
   rabbit: RabbitMQConfig;
@@ -45,6 +47,7 @@ export const appConfig = (): AppConfig => ({
     process.env.DATA_PROVIDER ?? 'supabase'
   ).toLowerCase() as DataProvider,
   stripeApiKey: process.env.STRIPE_API_KEY,
+  billingServiceAccountId: process.env.BILLING_SERVICE_ACCOUNT_ID,
   gql: {
     persistedQueriesTTL: +(process.env.PERSISTED_QUERIES_TTL ?? '86400'),
   },


### PR DESCRIPTION
## Summary
- add the BILLING_SERVICE_ACCOUNT_ID environment variable to the validated app config and README
- inject the billing service account id into CreateSubscriptionUseCase via a dedicated provider and use it when creating transactions

## Testing
- npm run lint *(fails: pre-existing lint violations in auth, billing supabase adapters, and user modules)*
- npm run test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2bc2f1a848328952f96eb986f146b