### PR TITLE
[service-template] Handle user.created listener idempotently

### DIFF
--- a/src/billing/application/listeners/user-created.listener.spec.ts
+++ b/src/billing/application/listeners/user-created.listener.spec.ts
@@ -1,0 +1,86 @@
+import { UserCreatedListener } from './user-created.listener';
+import { Customer } from '../../domain/entities/customer.entity';
+import { CustomerRepository } from '../../domain/repositories/customer.repository';
+import { PaymentGateway } from '../../infrastructure/payment/payment-gateway.interface';
+
+describe('UserCreatedListener', () => {
+  const buildMocks = () => {
+    const customerRepository: jest.Mocked<CustomerRepository> = {
+      findByUserId: jest.fn(),
+      findByCustomerId: jest.fn(),
+      create: jest.fn(),
+    };
+    const paymentGateway: jest.Mocked<PaymentGateway> = {
+      createCustomer: jest.fn(),
+      createSubscription: jest.fn(),
+      cancelSubscription: jest.fn(),
+    };
+    return { customerRepository, paymentGateway };
+  };
+
+  const payload = {
+    userId: 'user-1',
+    email: 'user@example.com',
+    name: 'User Name',
+  };
+
+  it('creates a customer when one does not exist', async () => {
+    const { customerRepository, paymentGateway } = buildMocks();
+    const listener = new UserCreatedListener(
+      customerRepository,
+      paymentGateway,
+    );
+
+    customerRepository.findByUserId.mockResolvedValue(undefined);
+    paymentGateway.createCustomer.mockResolvedValue({ customerId: 'cus_1' });
+    const createdCustomer = new Customer();
+    createdCustomer.userId = payload.userId;
+    createdCustomer.customerId = 'cus_1';
+    customerRepository.create.mockResolvedValue(createdCustomer);
+
+    await listener.handleUserCreatedEvent(payload);
+
+    const createCustomerMock =
+      paymentGateway.createCustomer as jest.MockedFunction<
+        PaymentGateway['createCustomer']
+      >;
+    expect(createCustomerMock).toHaveBeenCalledWith(
+      payload.email,
+      payload.name,
+    );
+    const repositoryCreateMock =
+      customerRepository.create as jest.MockedFunction<
+        CustomerRepository['create']
+      >;
+    expect(repositoryCreateMock).toHaveBeenCalledWith({
+      userId: payload.userId,
+      customerId: 'cus_1',
+    });
+  });
+
+  it('does not create a customer when one already exists', async () => {
+    const { customerRepository, paymentGateway } = buildMocks();
+    const listener = new UserCreatedListener(
+      customerRepository,
+      paymentGateway,
+    );
+
+    const existingCustomer = new Customer();
+    existingCustomer.userId = payload.userId;
+    existingCustomer.customerId = 'cus_existing';
+    customerRepository.findByUserId.mockResolvedValue(existingCustomer);
+
+    await listener.handleUserCreatedEvent(payload);
+
+    const createCustomerMock =
+      paymentGateway.createCustomer as jest.MockedFunction<
+        PaymentGateway['createCustomer']
+      >;
+    expect(createCustomerMock).not.toHaveBeenCalled();
+    const repositoryCreateMock =
+      customerRepository.create as jest.MockedFunction<
+        CustomerRepository['create']
+      >;
+    expect(repositoryCreateMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/billing/application/listeners/user-created.listener.ts
+++ b/src/billing/application/listeners/user-created.listener.ts
@@ -1,11 +1,47 @@
-import { Injectable } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 import { OnEvent } from '@nestjs/event-emitter';
+import {
+  CUSTOMER_REPOSITORY,
+  CustomerRepository,
+} from '../../domain/repositories/customer.repository';
+import {
+  PAYMENT_GATEWAY_TOKEN,
+  PaymentGateway,
+} from '../../infrastructure/payment/payment-gateway.interface';
+
+interface UserCreatedEventPayload {
+  userId: string;
+  email: string;
+  name: string;
+}
 
 @Injectable()
 export class UserCreatedListener {
+  constructor(
+    @Inject(CUSTOMER_REPOSITORY)
+    private readonly customerRepository: CustomerRepository,
+    @Inject(PAYMENT_GATEWAY_TOKEN)
+    private readonly paymentGateway: PaymentGateway,
+  ) {}
+
   @OnEvent('user.created')
-  handleUserCreatedEvent(payload: any) {
-    // will be implemented later
-    console.log('User created event received:', payload);
+  async handleUserCreatedEvent(payload: UserCreatedEventPayload) {
+    const existingCustomer = await this.customerRepository.findByUserId(
+      payload.userId,
+    );
+
+    if (existingCustomer) {
+      return;
+    }
+
+    const { customerId } = await this.paymentGateway.createCustomer(
+      payload.email,
+      payload.name,
+    );
+
+    await this.customerRepository.create({
+      customerId,
+      userId: payload.userId,
+    });
   }
 }


### PR DESCRIPTION
## Summary
- inject the customer repository and payment gateway into the billing user.created listener
- create Stripe customer records only when one does not already exist and persist the mapping
- cover the listener with unit tests that mock the payment gateway and repository

## Testing
- npm run lint *(fails: repository-wide pre-existing lint violations)*
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2bc228c4c83289d9beec7b4488a56